### PR TITLE
Remove redundant nil checks

### DIFF
--- a/service/debugger/locations.go
+++ b/service/debugger/locations.go
@@ -314,12 +314,9 @@ type AmbiguousLocationError struct {
 
 func (ale AmbiguousLocationError) Error() string {
 	var candidates []string
-	if ale.CandidatesLocation != nil {
-		for i := range ale.CandidatesLocation {
+	for i := range ale.CandidatesLocation {
 			candidates = append(candidates, ale.CandidatesLocation[i].Function.Name())
-		}
-
-	} else {
+		} else {
 		candidates = ale.CandidatesString
 	}
 	return fmt.Sprintf("Location \"%s\" ambiguous: %s…", ale.Location, strings.Join(candidates, ", "))


### PR DESCRIPTION
These nil checks before the range loop are redundant (see https://staticcheck.io/docs/gosimple#S1031)